### PR TITLE
Revert "Bump pyparsing from 2.4.7 to 3.0.6"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ packaging==21.2
 pluggy==1.0.0
 py==1.11.0
 Pygments==2.10.0
-pyparsing==3.0.6
+pyparsing==2.4.7
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-django==4.4.0


### PR DESCRIPTION
Reverts wesbuck/DominionCardAPI#137